### PR TITLE
Add sample program using SparseXML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-CFLAGS=-Wall -g -O0
+CFLAGS=-Wall -g -O0 -I.
 
-all: test-sparsexml
+all: test-sparsexml sample/simple
 
 test: test-sparsexml
 	./$<
@@ -8,10 +8,13 @@ test: test-sparsexml
 test-sparsexml: sparsexml.o test.o test-private.o test-oss-xml.o test-entities.o
 	$(CC) $(CFLAGS) -o $@ $^ -lcunit
 
+sample/simple: sparsexml.o sample/simple.o
+	$(CC) $(CFLAGS) -o $@ $^
+
 .c.o:
-	$(CC) $(CFLAGS) -c $<
+	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f test-sparsexml *.o
+	rm -f test-sparsexml sample/simple *.o sample/*.o
 
 .PHONY: clean all test

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ int main() {
 }
 ```
 
+## Sample Program
+A minimal demo is available in the `sample` directory. Build with `make` and run:
+
+```bash
+./sample/simple
+```
+to see parsing output.
+
 ## Limitations
 ⚠️ **Important**: This is a minimal parser with several limitations:
 
@@ -119,6 +127,7 @@ int main() {
 ```bash
 make
 ./test-sparsexml
+./sample/simple
 ```
 
 ## Memory Requirements

--- a/sample/simple.c
+++ b/sample/simple.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include "sparsexml.h"
+
+static unsigned char on_tag(char *name) {
+    printf("TAG: %s\n", name);
+    return SXMLExplorerContinue;
+}
+
+static unsigned char on_content(char *content) {
+    printf("CONTENT: %s\n", content);
+    return SXMLExplorerContinue;
+}
+
+static unsigned char on_attribute_key(char *key) {
+    printf("ATTR KEY: %s\n", key);
+    return SXMLExplorerContinue;
+}
+
+static unsigned char on_attribute_value(char *value) {
+    printf("ATTR VALUE: %s\n", value);
+    return SXMLExplorerContinue;
+}
+
+static unsigned char on_comment(char *text) {
+    printf("COMMENT: %s\n", text);
+    return SXMLExplorerContinue;
+}
+
+int main(void) {
+    SXMLExplorer *explorer = sxml_make_explorer();
+    sxml_enable_entity_processing(explorer, 1);
+    sxml_enable_namespace_processing(explorer, 1);
+    sxml_register_func(explorer, on_tag, on_content,
+                       on_attribute_key, on_attribute_value);
+    sxml_register_comment_func(explorer, on_comment);
+
+    char xml[] =
+        "<?xml version=\"1.0\"?>"
+        "<!-- Example XML -->"
+        "<ns:root attr=\"value\">Text<child>More</child></ns:root>";
+
+    sxml_run_explorer(explorer, xml);
+    sxml_destroy_explorer(explorer);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `sample/simple.c` demonstrating SparseXML API usage
- build sample from top-level `make`
- mention sample program in README with build/run instructions
- update Makefile to support building objects in subdirectories

## Testing
- `make sample/simple`
- `./sample/simple`
- `make` *(fails: `CUnit/CUnit.h` missing)*

------
https://chatgpt.com/codex/tasks/task_b_6860f8a743308332a9776629691b3d4a