### PR TITLE
Improve bench.c fairness with XML validation

### DIFF
--- a/examples/bench.c
+++ b/examples/bench.c
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include "sparsexml.h"
 
 static const char xml[] = "<?xml version=\"1.0\"?><root attr=\"value\">text<child>child</child></root>";
@@ -12,10 +13,17 @@ static unsigned int tag_count;
 static unsigned int content_count;
 static unsigned int attr_count;
 
+static unsigned int expat_tag_count;
+static unsigned int expat_content_count;
+static unsigned int expat_attr_count;
+
 static void reset_counters(void){
     tag_count = 0;
     content_count = 0;
     attr_count = 0;
+    expat_tag_count = 0;
+    expat_content_count = 0;
+    expat_attr_count = 0;
 }
 
 
@@ -23,6 +31,32 @@ static unsigned char tag_cb(char* tag){return SXMLExplorerContinue;}
 static unsigned char content_cb(char* content){return SXMLExplorerContinue;}
 static unsigned char attr_key_cb(char* key){return SXMLExplorerContinue;}
 static unsigned char attr_value_cb(char* val){return SXMLExplorerContinue;}
+
+static void expat_start(void *userData, const char *name, const char **atts){
+    (void)userData;
+    expat_tag_count++;
+    if(atts){
+        for(const char **a = atts; *a; a+=2){
+            expat_attr_count++;
+        }
+    }
+}
+
+static void expat_end(void *userData, const char *name){
+    (void)userData;
+    (void)name;
+    expat_tag_count++;
+}
+
+static void expat_char(void *userData, const char *s, int len){
+    (void)userData;
+    for(int i=0;i<len;i++){
+        if(!isspace((unsigned char)s[i])){
+            expat_content_count++;
+            break;
+        }
+    }
+}
 
 static unsigned char count_tag(char *name){
     tag_count++;
@@ -58,6 +92,20 @@ static void run_test(void){
     printf("[TEST] counters ok (tags=%u, contents=%u, attrs=%u)\n", tag_count, content_count, attr_count);
 }
 
+static void run_expat_test(void){
+    reset_counters();
+    XML_Parser p = XML_ParserCreate(NULL);
+    XML_SetElementHandler(p, expat_start, expat_end);
+    XML_SetCharacterDataHandler(p, expat_char);
+    int ret = XML_Parse(p, xml, strlen(xml), XML_TRUE);
+    XML_ParserFree(p);
+    assert(ret != XML_STATUS_ERROR);
+    assert(expat_tag_count == 4);
+    assert(expat_content_count == 2);
+    assert(expat_attr_count == 1);
+    printf("[TEST] expat counters ok (tags=%u, contents=%u, attrs=%u)\n", expat_tag_count, expat_content_count, expat_attr_count);
+}
+
 void bench_sparsexml(int iterations){
     SXMLExplorer* ex = sxml_make_explorer();
     sxml_register_func(ex, tag_cb, content_cb, attr_key_cb, attr_value_cb);
@@ -81,6 +129,7 @@ int main(int argc, char **argv){
         iter = atoi(argv[1]);
 
     run_test();
+    run_expat_test();
 
     clock_t start, end;
     start = clock();


### PR DESCRIPTION
## Summary
- validate the benchmark XML with Expat as well as SparseXML
- ensure both parsers count the same tags, contents and attributes

## Testing
- `make examples/bench`
- `./examples/bench 1`
- `make test-sparsexml`
- `./test-sparsexml`

------
https://chatgpt.com/codex/tasks/task_b_686119086e4c8332ad935775cf931c0b