### PR TITLE
Refine memory metrics

### DIFF
--- a/examples/bench.c
+++ b/examples/bench.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <malloc.h>
 #include "sparsexml.h"
 
 static const char xml[] = "<?xml version=\"1.0\"?><root attr=\"value\">text<child>child</child></root>";
@@ -16,6 +17,7 @@ static unsigned int attr_count;
 static unsigned int expat_tag_count;
 static unsigned int expat_content_count;
 static unsigned int expat_attr_count;
+
 
 static void reset_counters(void){
     tag_count = 0;
@@ -106,21 +108,40 @@ static void run_expat_test(void){
     printf("[TEST] expat counters ok (tags=%u, contents=%u, attrs=%u)\n", expat_tag_count, expat_content_count, expat_attr_count);
 }
 
-void bench_sparsexml(int iterations){
+void bench_sparsexml(int iterations, size_t *avg_mem, size_t *max_mem){
+    struct mallinfo2 mi = mallinfo2();
+    size_t start = mi.uordblks;
     SXMLExplorer* ex = sxml_make_explorer();
     sxml_register_func(ex, tag_cb, content_cb, attr_key_cb, attr_value_cb);
+    mi = mallinfo2();
+    size_t used = mi.uordblks - start;
+    size_t total = used * iterations;
+    size_t maximum = used;
     for(int i=0;i<iterations;i++){
         sxml_run_explorer(ex,(char*)xml);
     }
     sxml_destroy_explorer(ex);
+    if(avg_mem) *avg_mem = total / iterations;
+    if(max_mem) *max_mem = maximum;
 }
 
-void bench_expat(int iterations){
+void bench_expat(int iterations, size_t *avg_mem, size_t *max_mem){
+    struct mallinfo2 mi = mallinfo2();
+    size_t start = mi.uordblks;
+    size_t total = 0;
+    size_t maximum = 0;
     for(int i=0;i<iterations;i++){
         XML_Parser p = XML_ParserCreate(NULL);
+        mi = mallinfo2();
+        size_t used = mi.uordblks - start;
+        if(used > maximum)
+            maximum = used;
+        total += used;
         XML_Parse(p, xml, strlen(xml), XML_TRUE);
         XML_ParserFree(p);
     }
+    if(avg_mem) *avg_mem = total / iterations;
+    if(max_mem) *max_mem = maximum;
 }
 
 int main(int argc, char **argv){
@@ -132,17 +153,23 @@ int main(int argc, char **argv){
     run_expat_test();
 
     clock_t start, end;
+    size_t sparse_avg = 0, sparse_max = 0;
     start = clock();
-    bench_sparsexml(iter);
+    bench_sparsexml(iter, &sparse_avg, &sparse_max);
     end = clock();
     double sparse_time = (double)(end - start) / CLOCKS_PER_SEC;
 
+    size_t expat_avg = 0, expat_max = 0;
     start = clock();
-    bench_expat(iter);
+    bench_expat(iter, &expat_avg, &expat_max);
     end = clock();
     double expat_time = (double)(end - start) / CLOCKS_PER_SEC;
 
     printf("SparseXML: %f seconds for %d iterations\n", sparse_time, iter);
+    printf("  Avg memory: %zu bytes\n", sparse_avg);
+    printf("  Max memory: %zu bytes\n", sparse_max);
     printf("Expat:     %f seconds for %d iterations\n", expat_time, iter);
+    printf("  Avg memory: %zu bytes\n", expat_avg);
+    printf("  Max memory: %zu bytes\n", expat_max);
     return 0;
 }


### PR DESCRIPTION
## Summary
- switch to `mallinfo2()` for portable memory tracking
- compute average and maximum heap usage for each parser
- print memory usage in bytes

## Testing
- `make examples/bench`
- `make test-sparsexml`
- `./test-sparsexml`
- `./examples/bench 100`


------
https://chatgpt.com/codex/tasks/task_b_68611a9fcaec83328519a40c4f63c7f5