### PR TITLE
Combine bench binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.o
 test-sparsexml
-examples/bench
-examples/bench_large_mem
+bench/bench

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,12 @@ OBJ = $(SRC:.c=.o)
 TEST_SRC = test.c test-private.c test-oss-xml.c test-entities.c
 TEST_OBJ = $(TEST_SRC:.c=.o)
 
-EXAMPLES_SRC = examples/simple.c examples/bench.c examples/bench_large_mem.c
+EXAMPLES_SRC = examples/simple.c
 EXAMPLES_OBJ = $(EXAMPLES_SRC:.c=.o)
+BENCH_SRC = bench/bench.c bench/bench_large_mem.c bench/main.c
+BENCH_OBJ = $(BENCH_SRC:.c=.o)
 
-all: test-sparsexml examples/simple examples/bench examples/bench_large_mem
+all: test-sparsexml examples/simple bench/bench
 
 test: test-sparsexml
 	./$<
@@ -21,17 +23,18 @@ test-sparsexml: $(OBJ) $(TEST_OBJ)
 examples/simple: $(OBJ) examples/simple.o
 	$(CC) $(CFLAGS) -o $@ $^
 
-examples/bench: $(OBJ) examples/bench.o
+bench/bench: $(OBJ) $(BENCH_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ -lexpat
-
-examples/bench_large_mem: $(OBJ) examples/bench_large_mem.o
-	$(CC) $(CFLAGS) -o $@ $^ -lexpat
+bench/bench.o: bench/bench.c
+	$(CC) $(CFLAGS) -DBENCH_LIBRARY -c $< -o $@
+bench/bench_large_mem.o: bench/bench_large_mem.c
+	$(CC) $(CFLAGS) -DBENCH_LIBRARY -c $< -o $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJ) $(TEST_OBJ) $(EXAMPLES_OBJ)
-	rm -f test-sparsexml examples/simple examples/bench examples/bench_large_mem
+	rm -f $(OBJ) $(TEST_OBJ) $(EXAMPLES_OBJ) $(BENCH_OBJ)
+	rm -f test-sparsexml examples/simple bench/bench
 
 .PHONY: clean all test

--- a/bench/bench.c
+++ b/bench/bench.c
@@ -141,7 +141,12 @@ void bench_expat(int iterations, size_t *avg_mem, size_t *max_mem){
     if(max_mem) *max_mem = maximum;
 }
 
-int main(int argc, char **argv){
+#ifdef BENCH_LIBRARY
+int bench_basic_main(int argc, char **argv)
+#else
+int main(int argc, char **argv)
+#endif
+{
     int iter = 100000;
     if(argc > 1)
         iter = atoi(argv[1]);

--- a/bench/bench_large_mem.c
+++ b/bench/bench_large_mem.c
@@ -49,7 +49,12 @@ static size_t mem_usage_expat(char* xml){
     return used;
 }
 
-int main(int argc,char** argv){
+#ifdef BENCH_LIBRARY
+int bench_large_main(int argc,char **argv)
+#else
+int main(int argc,char **argv)
+#endif
+{
     int repeat = 1000;
     if(argc>1) repeat = atoi(argv[1]);
     char* xml = NULL;

--- a/bench/main.c
+++ b/bench/main.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <string.h>
+
+int bench_basic_main(int argc, char **argv);
+int bench_large_main(int argc, char **argv);
+
+int main(int argc, char **argv){
+    if(argc < 2){
+        fprintf(stderr, "Usage: %s [basic|large] [args...]\n", argv[0]);
+        return 1;
+    }
+    if(strcmp(argv[1], "large") == 0){
+        return bench_large_main(argc - 1, argv + 1);
+    }else if(strcmp(argv[1], "basic") == 0){
+        return bench_basic_main(argc - 1, argv + 1);
+    }else{
+        fprintf(stderr, "Unknown mode: %s\n", argv[1]);
+        return 1;
+    }
+}

--- a/paper.md
+++ b/paper.md
@@ -50,10 +50,10 @@ SparseXMLは1KB固定バッファを採用しており、その他のヒープ�
 SparseXMLはメモリフットプリントが小さいだけでなく、シンプルな実装によって高速に動作することが分かる。ただし、XML仕様への対応範囲は限定されるため、複雑な機能が必要な場合はlibexpatなどを選択すべきである。
 
 ### 4.4 追加テスト
-`examples/bench` にはベンチマークだけでなく簡単な検証用テストも備えている。XMLを1回だけ解析し、タグ数や属性数を確認した後にベンチマークを実行する形式だ。実行例を次に示す。
+`bench/bench` にはベンチマークだけでなく簡単な検証用テストも備えている。XMLを1回だけ解析し、タグ数や属性数を確認した後にベンチマークを実行する形式だ。実行例を次に示す。
 
 ```
-$ ./examples/bench 1000
+$ ./bench/bench basic 1000
 [TEST] counters ok (tags=4, contents=2, attrs=1)
 SparseXML: 0.05 seconds for 1000 iterations
 Expat:     0.30 seconds for 1000 iterations


### PR DESCRIPTION
## Summary
- move bench sources from `examples/` into new `bench/` directory
- combine the two bench programs under a single binary `bench/bench`
- update Makefile and `.gitignore` for new layout
- update documentation and examples

## Testing
- `make clean`
- `make all`
- `./test-sparsexml`
- `./bench/bench basic 1`
- `./bench/bench large 1`


------
https://chatgpt.com/codex/tasks/task_b_68612646a8fc8332aa432a8f2669fe11