### PR TITLE
Add extended benchmarks and automate bench execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,13 @@ TEST_OBJ = $(TEST_SRC:.c=.o)
 
 EXAMPLES_SRC = examples/simple.c
 EXAMPLES_OBJ = $(EXAMPLES_SRC:.c=.o)
-BENCH_SRC = bench/bench.c bench/bench_large_mem.c bench/main.c
+BENCH_SRC = bench/bench.c \
+            bench/bench_large_mem.c \
+            bench/bench_deep_nesting.c \
+            bench/bench_many_attrs.c \
+            bench/bench_comments.c \
+            bench/bench_entities.c \
+            bench/main.c
 BENCH_OBJ = $(BENCH_SRC:.c=.o)
 
 all: test-sparsexml examples/simple bench/bench
@@ -28,6 +34,14 @@ bench/bench: $(OBJ) $(BENCH_OBJ)
 bench/bench.o: bench/bench.c
 	$(CC) $(CFLAGS) -DBENCH_LIBRARY -c $< -o $@
 bench/bench_large_mem.o: bench/bench_large_mem.c
+	$(CC) $(CFLAGS) -DBENCH_LIBRARY -c $< -o $@
+bench/bench_deep_nesting.o: bench/bench_deep_nesting.c
+	$(CC) $(CFLAGS) -DBENCH_LIBRARY -c $< -o $@
+bench/bench_many_attrs.o: bench/bench_many_attrs.c
+	$(CC) $(CFLAGS) -DBENCH_LIBRARY -c $< -o $@
+bench/bench_comments.o: bench/bench_comments.c
+	$(CC) $(CFLAGS) -DBENCH_LIBRARY -c $< -o $@
+bench/bench_entities.o: bench/bench_entities.c
 	$(CC) $(CFLAGS) -DBENCH_LIBRARY -c $< -o $@
 
 %.o: %.c

--- a/bench/bench_comments.c
+++ b/bench/bench_comments.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <string.h>
+#include <expat.h>
+#include <malloc.h>
+#include "sparsexml.h"
+
+static unsigned char tag_cb(char* t){ return SXMLExplorerContinue; }
+static unsigned char content_cb(char* c){ return SXMLExplorerContinue; }
+static unsigned char key_cb(char* k){ return SXMLExplorerContinue; }
+static unsigned char val_cb(char* v){ return SXMLExplorerContinue; }
+static unsigned char comment_cb(char* c){ return SXMLExplorerContinue; }
+
+static void build_xml(char** out, int count){
+    const char frag[] = "<!-- comment -->";
+    size_t frag_len = strlen(frag);
+    size_t size = count * frag_len + strlen("<root></root>") + 1;
+    char *buf = malloc(size);
+    strcpy(buf, "<root>");
+    for(int i=0;i<count;i++) strcat(buf, frag);
+    strcat(buf, "</root>");
+    *out = buf;
+}
+
+static size_t mem_usage_sparsexml(char* xml){
+    struct mallinfo2 mi_before = mallinfo2();
+    SXMLExplorer *ex = sxml_make_explorer();
+    sxml_register_func(ex, tag_cb, content_cb, key_cb, val_cb);
+    sxml_register_comment_func(ex, comment_cb);
+    sxml_run_explorer(ex, xml);
+    struct mallinfo2 mi_after = mallinfo2();
+    size_t used = mi_after.uordblks - mi_before.uordblks;
+    sxml_destroy_explorer(ex);
+    return used;
+}
+
+static void start(void *ud,const char *name,const char **atts){ (void)ud; (void)name; (void)atts; }
+static void end(void *ud,const char *name){ (void)ud; (void)name; }
+static void ch(void *ud,const char *s,int len){ (void)ud; (void)s; (void)len; }
+static void comment_start(void *ud, const char *name, const char **atts){ (void)ud; (void)name; (void)atts; }
+
+static size_t mem_usage_expat(char* xml){
+    struct mallinfo2 mi_before = mallinfo2();
+    XML_Parser p = XML_ParserCreate(NULL);
+    XML_SetElementHandler(p, start, end);
+    XML_SetCharacterDataHandler(p, ch);
+    XML_Parse(p, xml, strlen(xml), XML_TRUE);
+    struct mallinfo2 mi_after = mallinfo2();
+    size_t used = mi_after.uordblks - mi_before.uordblks;
+    XML_ParserFree(p);
+    return used;
+}
+
+#ifdef BENCH_LIBRARY
+int bench_comments_main(int argc,char **argv)
+#else
+int main(int argc,char **argv)
+#endif
+{
+    int count = 100;
+    if(argc>1) count = atoi(argv[1]);
+    char* xml = NULL;
+    build_xml(&xml, count);
+    size_t sxml = mem_usage_sparsexml(xml);
+    size_t expat = mem_usage_expat(xml);
+    printf("Comments benchmark with %d comments\n", count);
+    printf("SparseXML memory: %zu bytes\n", sxml);
+    printf("Expat memory: %zu bytes\n", expat);
+    free(xml);
+    return 0;
+}

--- a/bench/bench_deep_nesting.c
+++ b/bench/bench_deep_nesting.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <string.h>
+#include <expat.h>
+#include <malloc.h>
+#include "sparsexml.h"
+
+static unsigned char tag_cb(char* t){ return SXMLExplorerContinue; }
+static unsigned char content_cb(char* c){ return SXMLExplorerContinue; }
+static unsigned char key_cb(char* k){ return SXMLExplorerContinue; }
+static unsigned char val_cb(char* v){ return SXMLExplorerContinue; }
+
+static void build_xml(char** out, int depth){
+    const char open[] = "<child>";
+    const char close[] = "</child>";
+    size_t size = depth*(strlen(open)+strlen(close)) + strlen("<root></root>text") + 1;
+    char* buf = malloc(size);
+    strcpy(buf, "<root>");
+    for(int i=0;i<depth;i++) strcat(buf, open);
+    strcat(buf, "text");
+    for(int i=0;i<depth;i++) strcat(buf, close);
+    strcat(buf, "</root>");
+    *out = buf;
+}
+
+static size_t mem_usage_sparsexml(char* xml){
+    struct mallinfo2 mi_before = mallinfo2();
+    SXMLExplorer *ex = sxml_make_explorer();
+    sxml_register_func(ex, tag_cb, content_cb, key_cb, val_cb);
+    sxml_run_explorer(ex, xml);
+    struct mallinfo2 mi_after = mallinfo2();
+    size_t used = mi_after.uordblks - mi_before.uordblks;
+    sxml_destroy_explorer(ex);
+    return used;
+}
+
+static void start(void *ud,const char *name,const char **atts){ (void)ud; (void)name; (void)atts; }
+static void end(void *ud,const char *name){ (void)ud; (void)name; }
+static void ch(void *ud,const char *s,int len){ (void)ud; (void)s; (void)len; }
+
+static size_t mem_usage_expat(char* xml){
+    struct mallinfo2 mi_before = mallinfo2();
+    XML_Parser p = XML_ParserCreate(NULL);
+    XML_SetElementHandler(p, start, end);
+    XML_SetCharacterDataHandler(p, ch);
+    XML_Parse(p, xml, strlen(xml), XML_TRUE);
+    struct mallinfo2 mi_after = mallinfo2();
+    size_t used = mi_after.uordblks - mi_before.uordblks;
+    XML_ParserFree(p);
+    return used;
+}
+
+#ifdef BENCH_LIBRARY
+int bench_deep_main(int argc,char **argv)
+#else
+int main(int argc,char **argv)
+#endif
+{
+    int depth = 100;
+    if(argc>1) depth = atoi(argv[1]);
+    char* xml = NULL;
+    build_xml(&xml, depth);
+    size_t sxml = mem_usage_sparsexml(xml);
+    size_t expat = mem_usage_expat(xml);
+    printf("Deep nesting with depth %d\n", depth);
+    printf("SparseXML memory: %zu bytes\n", sxml);
+    printf("Expat memory: %zu bytes\n", expat);
+    free(xml);
+    return 0;
+}

--- a/bench/bench_entities.c
+++ b/bench/bench_entities.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <string.h>
+#include <expat.h>
+#include <malloc.h>
+#include "sparsexml.h"
+
+static unsigned char tag_cb(char* t){ return SXMLExplorerContinue; }
+static unsigned char content_cb(char* c){ return SXMLExplorerContinue; }
+static unsigned char key_cb(char* k){ return SXMLExplorerContinue; }
+static unsigned char val_cb(char* v){ return SXMLExplorerContinue; }
+
+static void build_xml(char** out, int count){
+    const char frag[] = "&lt;&copy;&#65;";
+    size_t frag_len = strlen(frag);
+    size_t size = count * frag_len + strlen("<root></root>") + 1;
+    char *buf = malloc(size);
+    strcpy(buf, "<root>");
+    for(int i=0;i<count;i++) strcat(buf, frag);
+    strcat(buf, "</root>");
+    *out = buf;
+}
+
+static size_t mem_usage_sparsexml(char* xml){
+    struct mallinfo2 mi_before = mallinfo2();
+    SXMLExplorer *ex = sxml_make_explorer();
+    sxml_register_func(ex, tag_cb, content_cb, key_cb, val_cb);
+    sxml_enable_entity_processing(ex, 1);
+    sxml_enable_extended_entities(ex, 1);
+    sxml_enable_numeric_entities(ex, 1);
+    sxml_run_explorer(ex, xml);
+    struct mallinfo2 mi_after = mallinfo2();
+    size_t used = mi_after.uordblks - mi_before.uordblks;
+    sxml_destroy_explorer(ex);
+    return used;
+}
+
+static void start(void *ud,const char *name,const char **atts){ (void)ud; (void)name; (void)atts; }
+static void end(void *ud,const char *name){ (void)ud; (void)name; }
+static void ch(void *ud,const char *s,int len){ (void)ud; (void)s; (void)len; }
+
+static size_t mem_usage_expat(char* xml){
+    struct mallinfo2 mi_before = mallinfo2();
+    XML_Parser p = XML_ParserCreate(NULL);
+    XML_SetElementHandler(p, start, end);
+    XML_SetCharacterDataHandler(p, ch);
+    XML_Parse(p, xml, strlen(xml), XML_TRUE);
+    struct mallinfo2 mi_after = mallinfo2();
+    size_t used = mi_after.uordblks - mi_before.uordblks;
+    XML_ParserFree(p);
+    return used;
+}
+
+#ifdef BENCH_LIBRARY
+int bench_entities_main(int argc,char **argv)
+#else
+int main(int argc,char **argv)
+#endif
+{
+    int count = 1000;
+    if(argc>1) count = atoi(argv[1]);
+    char* xml = NULL;
+    build_xml(&xml, count);
+    size_t sxml = mem_usage_sparsexml(xml);
+    size_t expat = mem_usage_expat(xml);
+    printf("Entities benchmark with %d repetitions\n", count);
+    printf("SparseXML memory: %zu bytes\n", sxml);
+    printf("Expat memory: %zu bytes\n", expat);
+    free(xml);
+    return 0;
+}

--- a/bench/bench_many_attrs.c
+++ b/bench/bench_many_attrs.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <string.h>
+#include <expat.h>
+#include <malloc.h>
+#include "sparsexml.h"
+
+static unsigned char tag_cb(char* t){ return SXMLExplorerContinue; }
+static unsigned char content_cb(char* c){ return SXMLExplorerContinue; }
+static unsigned char key_cb(char* k){ return SXMLExplorerContinue; }
+static unsigned char val_cb(char* v){ return SXMLExplorerContinue; }
+
+static void build_xml(char** out, int count){
+    size_t size = strlen("<root />") + count * 16 + 1;
+    char *buf = malloc(size);
+    strcpy(buf, "<root");
+    for(int i=0;i<count;i++){
+        char tmp[16];
+        sprintf(tmp, " a%d=\"v\"", i);
+        strcat(buf, tmp);
+    }
+    strcat(buf, "/>");
+    *out = buf;
+}
+
+static size_t mem_usage_sparsexml(char* xml){
+    struct mallinfo2 mi_before = mallinfo2();
+    SXMLExplorer *ex = sxml_make_explorer();
+    sxml_register_func(ex, tag_cb, content_cb, key_cb, val_cb);
+    sxml_run_explorer(ex, xml);
+    struct mallinfo2 mi_after = mallinfo2();
+    size_t used = mi_after.uordblks - mi_before.uordblks;
+    sxml_destroy_explorer(ex);
+    return used;
+}
+
+static void start(void *ud,const char *name,const char **atts){ (void)ud; (void)name; (void)atts; }
+static void end(void *ud,const char *name){ (void)ud; (void)name; }
+static void ch(void *ud,const char *s,int len){ (void)ud; (void)s; (void)len; }
+
+static size_t mem_usage_expat(char* xml){
+    struct mallinfo2 mi_before = mallinfo2();
+    XML_Parser p = XML_ParserCreate(NULL);
+    XML_SetElementHandler(p, start, end);
+    XML_SetCharacterDataHandler(p, ch);
+    XML_Parse(p, xml, strlen(xml), XML_TRUE);
+    struct mallinfo2 mi_after = mallinfo2();
+    size_t used = mi_after.uordblks - mi_before.uordblks;
+    XML_ParserFree(p);
+    return used;
+}
+
+#ifdef BENCH_LIBRARY
+int bench_attrs_main(int argc,char **argv)
+#else
+int main(int argc,char **argv)
+#endif
+{
+    int count = 50;
+    if(argc>1) count = atoi(argv[1]);
+    char* xml = NULL;
+    build_xml(&xml, count);
+    size_t sxml = mem_usage_sparsexml(xml);
+    size_t expat = mem_usage_expat(xml);
+    printf("Many attributes with count %d\n", count);
+    printf("SparseXML memory: %zu bytes\n", sxml);
+    printf("Expat memory: %zu bytes\n", expat);
+    free(xml);
+    return 0;
+}

--- a/bench/main.c
+++ b/bench/main.c
@@ -3,18 +3,18 @@
 
 int bench_basic_main(int argc, char **argv);
 int bench_large_main(int argc, char **argv);
+int bench_deep_main(int argc, char **argv);
+int bench_attrs_main(int argc, char **argv);
+int bench_comments_main(int argc, char **argv);
+int bench_entities_main(int argc, char **argv);
 
 int main(int argc, char **argv){
-    if(argc < 2){
-        fprintf(stderr, "Usage: %s [basic|large] [args...]\n", argv[0]);
-        return 1;
-    }
-    if(strcmp(argv[1], "large") == 0){
-        return bench_large_main(argc - 1, argv + 1);
-    }else if(strcmp(argv[1], "basic") == 0){
-        return bench_basic_main(argc - 1, argv + 1);
-    }else{
-        fprintf(stderr, "Unknown mode: %s\n", argv[1]);
-        return 1;
-    }
+    (void)argc; (void)argv;
+    bench_basic_main(argc, argv);
+    bench_large_main(argc, argv);
+    bench_deep_main(argc, argv);
+    bench_attrs_main(argc, argv);
+    bench_comments_main(argc, argv);
+    bench_entities_main(argc, argv);
+    return 0;
 }


### PR DESCRIPTION
## Summary
- extend benchmark suite with four new scenarios
- update Makefile for new benchmark sources
- run all benchmarks automatically

## Testing
- `make -j$(nproc)`
- `make test`
- `./bench/bench`

------
https://chatgpt.com/codex/tasks/task_b_68612d4ebe0c8332a3f52e3f9e85723d