### PR TITLE
Format bench output as table

### DIFF
--- a/bench/bench.c
+++ b/bench/bench.c
@@ -154,6 +154,9 @@ int main(int argc, char **argv)
     run_test();
     run_expat_test();
 
+    /* Print table header once */
+    printf("Benchmark\tParam\tSparseXML(bytes)\tExpat(bytes)\tSparse time(s)\tExpat time(s)\n");
+
     clock_t start, end;
     size_t sparse_avg = 0, sparse_max = 0;
     start = clock();
@@ -167,11 +170,10 @@ int main(int argc, char **argv)
     end = clock();
     double expat_time = (double)(end - start) / CLOCKS_PER_SEC;
 
-    printf("SparseXML: %f seconds for %d iterations\n", sparse_time, iter);
-    printf("  Avg memory: %zu bytes\n", sparse_avg);
-    printf("  Max memory: %zu bytes\n", sparse_max);
-    printf("Expat:     %f seconds for %d iterations\n", expat_time, iter);
-    printf("  Avg memory: %zu bytes\n", expat_avg);
-    printf("  Max memory: %zu bytes\n", expat_max);
+    /* Print as a single table row using tab separators */
+    printf("basic\t%d\t%zu\t%zu\t%f\t%f\n",
+           iter, sparse_avg, expat_avg, sparse_time, expat_time);
+    (void)sparse_max; /* keep variables unused in case future metrics needed */
+    (void)expat_max;
     return 0;
 }

--- a/bench/bench_comments.c
+++ b/bench/bench_comments.c
@@ -62,9 +62,7 @@ int main(int argc,char **argv)
     build_xml(&xml, count);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("Comments benchmark with %d comments\n", count);
-    printf("SparseXML memory: %zu bytes\n", sxml);
-    printf("Expat memory: %zu bytes\n", expat);
+    printf("comments\t%d\t%zu\t%zu\t0\t0\n", count, sxml, expat);
     free(xml);
     return 0;
 }

--- a/bench/bench_deep_nesting.c
+++ b/bench/bench_deep_nesting.c
@@ -61,9 +61,7 @@ int main(int argc,char **argv)
     build_xml(&xml, depth);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("Deep nesting with depth %d\n", depth);
-    printf("SparseXML memory: %zu bytes\n", sxml);
-    printf("Expat memory: %zu bytes\n", expat);
+    printf("deep_nesting\t%d\t%zu\t%zu\t0\t0\n", depth, sxml, expat);
     free(xml);
     return 0;
 }

--- a/bench/bench_entities.c
+++ b/bench/bench_entities.c
@@ -62,9 +62,7 @@ int main(int argc,char **argv)
     build_xml(&xml, count);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("Entities benchmark with %d repetitions\n", count);
-    printf("SparseXML memory: %zu bytes\n", sxml);
-    printf("Expat memory: %zu bytes\n", expat);
+    printf("entities\t%d\t%zu\t%zu\t0\t0\n", count, sxml, expat);
     free(xml);
     return 0;
 }

--- a/bench/bench_large_mem.c
+++ b/bench/bench_large_mem.c
@@ -61,9 +61,8 @@ int main(int argc,char **argv)
     build_xml(&xml, repeat);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("Large XML with %d children\n", repeat);
-    printf("SparseXML memory: %zu bytes\n", sxml);
-    printf("Expat memory: %zu bytes\n", expat);
+    /* Single table row */
+    printf("large_mem\t%d\t%zu\t%zu\t0\t0\n", repeat, sxml, expat);
     free(xml);
     return 0;
 }

--- a/bench/bench_many_attrs.c
+++ b/bench/bench_many_attrs.c
@@ -61,9 +61,7 @@ int main(int argc,char **argv)
     build_xml(&xml, count);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("Many attributes with count %d\n", count);
-    printf("SparseXML memory: %zu bytes\n", sxml);
-    printf("Expat memory: %zu bytes\n", expat);
+    printf("many_attrs\t%d\t%zu\t%zu\t0\t0\n", count, sxml, expat);
     free(xml);
     return 0;
 }

--- a/bench/main.c
+++ b/bench/main.c
@@ -10,6 +10,7 @@ int bench_entities_main(int argc, char **argv);
 
 int main(int argc, char **argv){
     (void)argc; (void)argv;
+
     bench_basic_main(argc, argv);
     bench_large_main(argc, argv);
     bench_deep_main(argc, argv);


### PR DESCRIPTION
## Summary
- change bench programs to print results as a tab-separated table
- print table header after basic tests

## Testing
- `make bench/bench`
- `./bench/bench | head`
- `make test-sparsexml`
- `./test-sparsexml`

------
https://chatgpt.com/codex/tasks/task_b_68612f1151ac83328be931801fb372ab