### PR TITLE
Improve benchmark table formatting

### DIFF
--- a/bench/bench.c
+++ b/bench/bench.c
@@ -154,8 +154,10 @@ int main(int argc, char **argv)
     run_test();
     run_expat_test();
 
-    /* Print table header once */
-    printf("Benchmark\tParam\tSparseXML(bytes)\tExpat(bytes)\tSparse time(s)\tExpat time(s)\n");
+    /* Print table header once with aligned columns */
+    printf("%-12s | %-8s | %-18s | %-14s | %-16s | %-16s\n",
+           "Benchmark", "Param", "SparseXML(bytes)",
+           "Expat(bytes)", "Sparse time(s)", "Expat time(s)");
 
     clock_t start, end;
     size_t sparse_avg = 0, sparse_max = 0;
@@ -170,9 +172,9 @@ int main(int argc, char **argv)
     end = clock();
     double expat_time = (double)(end - start) / CLOCKS_PER_SEC;
 
-    /* Print as a single table row using tab separators */
-    printf("basic\t%d\t%zu\t%zu\t%f\t%f\n",
-           iter, sparse_avg, expat_avg, sparse_time, expat_time);
+    /* Print as a single table row matching the header format */
+    printf("%-12s | %8d | %18zu | %14zu | %16.6f | %16.6f\n",
+           "basic", iter, sparse_avg, expat_avg, sparse_time, expat_time);
     (void)sparse_max; /* keep variables unused in case future metrics needed */
     (void)expat_max;
     return 0;

--- a/bench/bench_comments.c
+++ b/bench/bench_comments.c
@@ -62,7 +62,8 @@ int main(int argc,char **argv)
     build_xml(&xml, count);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("comments\t%d\t%zu\t%zu\t0\t0\n", count, sxml, expat);
+    printf("%-12s | %8d | %18zu | %14zu | %16.6f | %16.6f\n",
+           "comments", count, sxml, expat, 0.0, 0.0);
     free(xml);
     return 0;
 }

--- a/bench/bench_deep_nesting.c
+++ b/bench/bench_deep_nesting.c
@@ -61,7 +61,8 @@ int main(int argc,char **argv)
     build_xml(&xml, depth);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("deep_nesting\t%d\t%zu\t%zu\t0\t0\n", depth, sxml, expat);
+    printf("%-12s | %8d | %18zu | %14zu | %16.6f | %16.6f\n",
+           "deep_nesting", depth, sxml, expat, 0.0, 0.0);
     free(xml);
     return 0;
 }

--- a/bench/bench_entities.c
+++ b/bench/bench_entities.c
@@ -62,7 +62,8 @@ int main(int argc,char **argv)
     build_xml(&xml, count);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("entities\t%d\t%zu\t%zu\t0\t0\n", count, sxml, expat);
+    printf("%-12s | %8d | %18zu | %14zu | %16.6f | %16.6f\n",
+           "entities", count, sxml, expat, 0.0, 0.0);
     free(xml);
     return 0;
 }

--- a/bench/bench_large_mem.c
+++ b/bench/bench_large_mem.c
@@ -61,8 +61,9 @@ int main(int argc,char **argv)
     build_xml(&xml, repeat);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    /* Single table row */
-    printf("large_mem\t%d\t%zu\t%zu\t0\t0\n", repeat, sxml, expat);
+    /* Single table row aligned with header */
+    printf("%-12s | %8d | %18zu | %14zu | %16.6f | %16.6f\n",
+           "large_mem", repeat, sxml, expat, 0.0, 0.0);
     free(xml);
     return 0;
 }

--- a/bench/bench_many_attrs.c
+++ b/bench/bench_many_attrs.c
@@ -61,7 +61,8 @@ int main(int argc,char **argv)
     build_xml(&xml, count);
     size_t sxml = mem_usage_sparsexml(xml);
     size_t expat = mem_usage_expat(xml);
-    printf("many_attrs\t%d\t%zu\t%zu\t0\t0\n", count, sxml, expat);
+    printf("%-12s | %8d | %18zu | %14zu | %16.6f | %16.6f\n",
+           "many_attrs", count, sxml, expat, 0.0, 0.0);
     free(xml);
     return 0;
 }


### PR DESCRIPTION
## Summary
- format benchmark table as an aligned grid

## Testing
- `make bench/bench`
- `./bench/bench | head`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_6861308485488332a588c3188527e8e3