### PR TITLE
feat: Enhance EXI support with namespaces and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,23 @@ sxml_enable_extended_entities(explorer, 1);      // &copy;, &reg;, etc.
 ## Latest Updates (v2.2) - Experimental EXI Support
 This release introduces a very small EXI decoder capable of parsing a limited
 subset of EXI streams. The new API function `sxml_run_explorer_exi()` allows
-feeding binary EXI data directly into the explorer. Only start/end elements,
-attributes, character content, and comments are recognized. Full conformance to
+feeding binary EXI data directly into the explorer. Full conformance to
 the EXI specification is **not** implemented.
+
+The current EXI support is based on a custom binary format, not the official W3C EXI specification. It provides a subset of EXI features for resource-constrained environments.
+
+### Supported Features
+
+*   **Start Element:** `0x01`
+*   **End Element:** `0x02`
+*   **Attribute:** `0x03`
+*   **Characters:** `0x04`
+*   **Comment:** `0x05`
+*   **Namespace-prefixed Tag:** `0x06`
+
+### Known Issues
+
+*   The namespace implementation uses `sprintf`, which may cause buffer overflows with long URIs or local names. This is mitigated by length checks but will be replaced with a safer alternative in a future update.
 
 ## Future Enhancements
 Potential improvements for future versions:

--- a/test-exi.c
+++ b/test-exi.c
@@ -34,6 +34,56 @@ void test_parse_simple_exi(void) {
   sxml_destroy_explorer(ex);
 }
 
+static unsigned int exi_attr_key_count = 0;
+static unsigned int exi_attr_val_count = 0;
+
+static unsigned char exi_on_attr_key(char *key) {
+  CU_ASSERT(strcmp(key, "key") == 0);
+  exi_attr_key_count++;
+  return SXMLExplorerContinue;
+}
+
+static unsigned char exi_on_attr_val(char *val) {
+  CU_ASSERT(strcmp(val, "value") == 0);
+  exi_attr_val_count++;
+  return SXMLExplorerContinue;
+}
+
+void test_parse_exi_with_attribute(void) {
+  unsigned char exi[] = {0x01, 4, 'r','o','o','t', 0x03, 3, 'k','e','y', 5, 'v','a','l','u','e', 0x02, 4, 'r','o','o','t', 0xFF};
+  SXMLExplorer* ex = sxml_make_explorer();
+  sxml_register_func(ex, NULL, NULL, exi_on_attr_key, exi_on_attr_val);
+  unsigned char ret = sxml_run_explorer_exi(ex, exi, sizeof(exi));
+  CU_ASSERT(ret == SXMLExplorerComplete);
+  CU_ASSERT(exi_attr_key_count == 1);
+  CU_ASSERT(exi_attr_val_count == 1);
+  sxml_destroy_explorer(ex);
+}
+
+static unsigned int exi_ns_tag_count = 0;
+
+static unsigned char exi_on_ns_tag(char *name) {
+  if (exi_ns_tag_count == 0) {
+    CU_ASSERT(strcmp(name, "ns:root") == 0);
+  } else if (exi_ns_tag_count == 1) {
+    CU_ASSERT(strcmp(name, "/root") == 0);
+  }
+  exi_ns_tag_count++;
+  return SXMLExplorerContinue;
+}
+
+void test_parse_exi_with_namespace(void) {
+  unsigned char exi[] = {0x06, 2, 'n','s', 4, 'r','o','o','t', 0x02, 4, 'r','o','o','t', 0xFF};
+  SXMLExplorer* ex = sxml_make_explorer();
+  sxml_register_func(ex, exi_on_ns_tag, NULL, NULL, NULL);
+  unsigned char ret = sxml_run_explorer_exi(ex, exi, sizeof(exi));
+  CU_ASSERT(ret == SXMLExplorerComplete);
+  CU_ASSERT(exi_ns_tag_count == 2);
+  sxml_destroy_explorer(ex);
+}
+
 void add_exi_tests(CU_pSuite* suite) {
   CU_add_test(*suite, "Parse simple EXI", test_parse_simple_exi);
+  CU_add_test(*suite, "Parse EXI with attribute", test_parse_exi_with_attribute);
+  CU_add_test(*suite, "Parse EXI with namespace", test_parse_exi_with_namespace);
 }


### PR DESCRIPTION
This commit enhances the experimental EXI support by:

1.  **Adding Namespace Support:** A new token (0x06) is introduced to parse namespace-prefixed tags. The parser now correctly handles tags like `<ns:tag>`.
2.  **Verifying Attribute Parsing:** Although attribute parsing logic existed, it was untested. A new test case has been added to verify that attributes are parsed correctly.
3.  **Expanding Test Coverage:** New tests for both attribute and namespace parsing have been added to `test-exi.c`.
4.  **Updating Documentation:** The `README.md` file has been updated to reflect the current state of the custom EXI implementation, including supported features and known issues.