### PR TITLE
Refactor buffer helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 test-sparsexml
 bench/bench
 examples/simple
+exificient/

--- a/sparsexml-priv.h
+++ b/sparsexml-priv.h
@@ -32,5 +32,7 @@ unsigned char priv_sxml_process_entity(SXMLExplorer* explorer, char* entity_buff
 unsigned char priv_sxml_process_numeric_entity(SXMLExplorer* explorer, char* entity_buffer);
 unsigned char priv_sxml_process_extended_entity(SXMLExplorer* explorer, char* entity_buffer);
 void priv_sxml_process_namespace(char* tag_name, char** namespace_uri, char** local_name);
+unsigned char priv_append_char(SXMLExplorer* explorer, char c);
+unsigned char priv_append_string(SXMLExplorer* explorer, const char* str);
 
 #endif


### PR DESCRIPTION
## Summary
- add `exificient/` to `.gitignore`
- introduce helper functions to append characters and strings
- simplify entity processing using new helpers

## Testing
- `make test-sparsexml`
- `./test-sparsexml`
- `make examples/simple`
- `./examples/simple`
- `make bench/bench`

------
https://chatgpt.com/codex/tasks/task_b_6885d25c2bc88332997d66147f508166