### PR TITLE
Improve sitemap EXI test

### DIFF
--- a/test-chunked.c
+++ b/test-chunked.c
@@ -128,7 +128,7 @@ void test_chunked_sitemap(void) {
     sxml_register_func(ex, sitemap_on_tag, NULL, NULL, NULL);
     unsigned char ret = feed_chunks(ex, xml, 32);
     CU_ASSERT_EQUAL(ret, SXMLExplorerComplete);
-    CU_ASSERT(sitemap_tag_count > 0);
+    CU_ASSERT_EQUAL(sitemap_tag_count, 12);
     sxml_destroy_explorer(ex);
     free(xml);
 }

--- a/test-entities.c
+++ b/test-entities.c
@@ -280,7 +280,7 @@ void test_complex_real_world_entities(void) {
   unsigned char result = sxml_run_explorer(explorer, xml);
   
   CU_ASSERT(result == SXMLExplorerComplete);
-  CU_ASSERT(test_complex_content_count >= 4);
+  CU_ASSERT_EQUAL(test_complex_content_count, 10);
   CU_ASSERT(found_amp == 1);
   CU_ASSERT(found_copy == 1);
   CU_ASSERT(found_code == 1);

--- a/test-exi.c
+++ b/test-exi.c
@@ -55,8 +55,8 @@ void test_parse_atom_feed_exi(void) {
   unsigned char ret = sxml_run_explorer_exi(ex, buf, size);
 
   CU_ASSERT(ret == SXMLExplorerComplete);
-  CU_ASSERT(atom_exi_tag_count >= 10);
-  CU_ASSERT(atom_exi_content_count >= 5);
+  CU_ASSERT_EQUAL(atom_exi_tag_count, 15);
+  CU_ASSERT_EQUAL(atom_exi_content_count, 15);
   CU_ASSERT(atom_exi_comment_count == 1);
   CU_ASSERT(atom_exi_found_entities == 1);
 
@@ -219,8 +219,8 @@ void test_sitemap_exi(void) {
 
     unsigned char result = sxml_run_explorer_exi(explorer, exi, exi_size);
     CU_ASSERT_EQUAL(result, SXMLExplorerComplete);
-    CU_ASSERT(sitemap_exi_tag_count > 0);
-    CU_ASSERT(sitemap_exi_content_count > 0);
+    CU_ASSERT_EQUAL(sitemap_exi_tag_count, 10);
+    CU_ASSERT_EQUAL(sitemap_exi_content_count, 10);
     CU_ASSERT(sitemap_exi_found_namespace == 0);
 
     sxml_destroy_explorer(explorer);

--- a/test-oss-xml.c
+++ b/test-oss-xml.c
@@ -69,8 +69,8 @@ void test_real_world_xml_sitemap(void) {
   unsigned char result = sxml_run_explorer(explorer, xml);
   
   CU_ASSERT(result == SXMLExplorerComplete);
-  CU_ASSERT(sitemap_tag_count > 0);  // Should parse multiple tags
-  CU_ASSERT(sitemap_content_count > 0);  // Should parse content
+  CU_ASSERT_EQUAL(sitemap_tag_count, 12);  // Should parse multiple tags
+  CU_ASSERT_EQUAL(sitemap_content_count, 12);  // Should parse content
   CU_ASSERT(sitemap_found_namespace == 1);  // Should handle namespace
   
   sxml_destroy_explorer(explorer);
@@ -132,8 +132,8 @@ void test_real_world_atom_feed(void) {
   unsigned char result = sxml_run_explorer(explorer, xml);
   
   CU_ASSERT(result == SXMLExplorerComplete);
-  CU_ASSERT(atom_tag_count >= 10);  // Should parse many tags
-  CU_ASSERT(atom_content_count >= 5);  // Should parse content elements
+  CU_ASSERT_EQUAL(atom_tag_count, 26);  // Should parse many tags
+  CU_ASSERT_EQUAL(atom_content_count, 24);  // Should parse content elements
   CU_ASSERT(atom_comment_count == 1);  // Should find the comment
   CU_ASSERT(atom_found_entities == 1);  // Should process entities
 
@@ -211,8 +211,8 @@ void test_complex_xml_with_cdata_and_entities(void) {
   
   // Should complete successfully with supported entities only
   CU_ASSERT(result == SXMLExplorerComplete);
-  CU_ASSERT(complex_tag_count >= 6);  // Should parse multiple tags (root, config, app:setting, description, data, footer)
-  CU_ASSERT(complex_content_count >= 3);  // Should parse multiple content sections
+  CU_ASSERT_EQUAL(complex_tag_count, 12);  // Should parse multiple tags (root, config, app:setting, description, data, footer)
+  CU_ASSERT_EQUAL(complex_content_count, 12);  // Should parse multiple content sections
   CU_ASSERT(complex_comment_count == 1);  // Should find the comment
   CU_ASSERT(complex_found_cdata == 1);  // Should process CDATA section
   CU_ASSERT(complex_found_entities == 1);  // Should find content (entities processed)
@@ -257,7 +257,7 @@ void test_error_handling_with_malformed_xml(void) {
   CU_ASSERT(result == SXMLExplorerComplete || 
             result == SXMLExplorerErrorInvalidEntity ||
             result == SXMLExplorerErrorMalformedXML);
-  CU_ASSERT(error_tag_count > 0);  // Should parse some tags before errors
+  CU_ASSERT_EQUAL(error_tag_count, 5);  // Should parse some tags before errors
   
   sxml_destroy_explorer(explorer);
 }


### PR DESCRIPTION
## Summary
- adjust sitemap EXI checks to verify exact tag and content counts
- tighten remaining XML tests so they assert explicit tag/content totals

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68880fd44c44833296a7fb1f5bd089c6